### PR TITLE
add support for eu-de region

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@
 repos:
   - repo: git@github.ibm.com:Whitewater/whitewater-detect-secrets
     # If you desire to use a specific version of whitewater-detect-secrets, you can replace `master` with other git revisions such as branch, tag or commit sha.
-    rev: 0.13.1+ibm.61.dss
+    rev: 0.13.1+ibm.62.dss
     hooks:
       - id: detect-secrets # pragma: whitelist secret
         # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-07-17T05:13:11Z",
+  "generated_at": "2024-03-16T19:19:07Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -61,7 +61,7 @@
     }
   ],
   "results": {},
-  "version": "0.13.1+ibm.61.dss",
+  "version": "0.13.1+ibm.62.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Choose to integrate the AppConfiguration Android client SDK package using either
 
         ```kt
         dependencies {
-	        implementation "com.ibm.cloud:appconfiguration-android-sdk:0.3.1"
+	        implementation "com.ibm.cloud:appconfiguration-android-sdk:0.3.2"
 	    }
         ```
         
@@ -97,6 +97,7 @@ using **`AppConfiguration.getInstance()`**.  [See this example below](#fetching-
     - `AppConfiguration.REGION_EU_GB` for London
     - `AppConfiguration.REGION_AU_SYD` for Sydney
     - `AppConfiguration.REGION_US_EAST` for Washington DC
+    - `AppConfiguration.REGION_EU_DE` for Frankfurt
 - guid : GUID of the App Configuration service. Get it from the service instance credentials section of the dashboard
 - apikey : ApiKey of the App Configuration service. Get it from the service instance credentials section of the dashboard
 - collectionId : Id of the collection created in App Configuration service instance under the **Collections** section.
@@ -353,7 +354,7 @@ Choose to integrate the AppConfiguration Android client SDK package using either
 
         ```java
         dependencies {
-	        implementation "com.ibm.cloud:appconfiguration-android-sdk:0.3.1"
+	        implementation "com.ibm.cloud:appconfiguration-android-sdk:0.3.2"
 	    }
         ```
     
@@ -413,6 +414,7 @@ using **`AppConfiguration.getInstance()`**.  [See this example below](#fetching-
     - `AppConfiguration.REGION_EU_GB` for London
     - `AppConfiguration.REGION_AU_SYD` for Sydney
     - `AppConfiguration.REGION_US_EAST` for Washington DC
+    - `AppConfiguration.REGION_EU_DE` for Frankfurt
 - guid : GUID of the App Configuration service. Get it from the service instance credentials section of the dashboard
 - apikey : ApiKey of the App Configuration service. Get it from the service instance credentials section of the dashboard
 - collectionId : Id of the collection created in App Configuration service instance under the **Collections** section.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,8 +4,8 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
-    buildToolsVersion "30.0.3"
+    compileSdkVersion 34
+    buildToolsVersion "34.0.0"
 
     android.sourceSets {
         debug.java.srcDirs += "src/debug/kotlin"
@@ -15,7 +15,7 @@ android {
     defaultConfig {
         applicationId "com.ibm.cloud.sampleapp"
         minSdkVersion 22
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 
@@ -42,9 +42,9 @@ dependencies {
 
     implementation project(path: ':lib')
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.core:core-ktx:1.12.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'com.google.android.material:material:1.11.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/build.gradle
+++ b/build.gradle
@@ -1,21 +1,21 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        kotlin_version = "1.9.0"
+        kotlin_version = '1.9.23'
     }
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.3.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.8.20")
+        classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.9.20")
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.25.3'
-        classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.8.20'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.28.0'
+        classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.9.20'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 #RELEASE FIELD SECTION
-VERSION_NAME=0.3.1
+VERSION_NAME=0.3.2
 GROUP=com.ibm.cloud
 POM_ARTIFACT_ID=appconfiguration-android-sdk
 POM_NAME=IBM App Configuration Android Client SDK

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jul 14 13:01:06 IST 2023
+#Thu Mar 14 15:45:11 IST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -9,8 +9,8 @@ apply from: '../jacoco.gradle'
 
 
 android {
-    compileSdkVersion 33
-    buildToolsVersion "33.0.2"
+    compileSdkVersion 34
+    buildToolsVersion "34.0.0"
 
     android.sourceSets {
         debug.java.srcDirs += "src/debug/kotlin"
@@ -21,8 +21,8 @@ android {
 
     defaultConfig {
         minSdkVersion 22
-        targetSdkVersion 33
-        buildConfigField 'String', 'VERSION_NAME', "\"0.3.1\""
+        targetSdkVersion 34
+        buildConfigField 'String', 'VERSION_NAME', "\"0.3.2\""
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -68,17 +68,17 @@ android {
 dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.core:core-ktx:1.12.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.google.android.material:material:1.9.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.2'
-    implementation 'com.ibm.cloud:sdk-core:9.18.4'
-    implementation 'commons-codec:commons-codec:1.16.0'
+    implementation 'com.google.android.material:material:1.11.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0'
+    implementation 'com.ibm.cloud:sdk-core:9.20.1'
+    implementation 'commons-codec:commons-codec:1.16.1'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.json:json:20230618'
+    testImplementation 'org.json:json:20240303'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:5.0.0-alpha.11'
-    testImplementation "io.mockk:mockk:1.13.5"
-    testImplementation 'org.mockito.kotlin:mockito-kotlin:5.0.0'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:5.0.0-alpha.12'
+    testImplementation 'io.mockk:mockk:1.13.10'
+    testImplementation 'org.mockito.kotlin:mockito-kotlin:5.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/lib/src/main/kotlin/com/ibm/cloud/appconfiguration/android/sdk/AppConfiguration.kt
+++ b/lib/src/main/kotlin/com/ibm/cloud/appconfiguration/android/sdk/AppConfiguration.kt
@@ -37,7 +37,7 @@ import kotlinx.coroutines.launch
  * Toggle feature flag states in the cloud to activate or deactivate features in your application or
  * environment, when required. You can also manage the properties for distributed applications centrally.
  *
- * @version 0.3.1
+ * @version 0.3.2
  * @see <a href="https://cloud.ibm.com/docs/app-configuration">App Configuration</a>
  */
 
@@ -65,6 +65,7 @@ class AppConfiguration {
         const val REGION_EU_GB = "eu-gb"
         const val REGION_AU_SYD = "au-syd"
         const val REGION_US_EAST = "us-east"
+        const val REGION_EU_DE = "eu-de"
         /**
          * Returns an instance of the [AppConfiguration] class. If the same [AppConfiguration] instance
          * is available in the cache, then that instance is returned.


### PR DESCRIPTION
- add SDK support for IBM Cloud region - `eu-de`
- bump dependencies
- bump gradle version, buildToolsVersion, compileSdkVersion, targetSdkVersion
- bump kotlin version
- bump SDK patch version. SDK new version is v0.3.2